### PR TITLE
Scroll speed equation, tooltip and scroll without holding

### DIFF
--- a/script.ahk
+++ b/script.ahk
@@ -7,32 +7,41 @@
 		; check if the cursor is in a text area
 		; if no, send a regular middle click
 		; if yes, scroll
+		global noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 		smooth := 80 ; higher smooth value makes scroll less smooth
 		acceleration := 1.09 ; higher acceleration value makes scroll start accelerating sooner
 		slow := 10 ; lower slow value increases scroll speed
 		symbol := Chr(10021) ; html character code for four direction arrow symbol
+		verticalScroll(y, yinit) {
+			if (y < yinit - noScrollZone) ; up
+				send, {WheelUp 1}
+			if (y > yinit + noScrollZone) ; down
+				send, {WheelDown 1}
+		}
+		horizontalScroll(x, xinit) {
+			if (x < xinit - noScrollZone) ; left
+				send, {WheelLeft 1}
+			if (x > xinit + noScrollZone) ; right
+				send, {WheelRight 1}
+		}
 		if (A_Cursor != "IBeam") {
 			send {MButton}
 		} else {
 			scroll := true ; activate scroll
-			noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 			MouseGetPos, xinit , yinit ; initial position of cursor when middle mouse button is clicked
+			; the tooltip is locked to its initial position
+			ToolTip, %symbol%, xinit, yinit ; visual indication that scroll is active
 			while scroll { ; loop until middle mouse button is released
-				; the tooltip is locked to its initial position
-				ToolTip, %symbol%, xinit, yinit ; visual indication that scroll is active
 				MouseGetPos, x , y ; current position of cursor
 				; check the four cases
-				if (y < yinit - noScrollZone) ; up
-					send, {WheelUp 1}
-				if (y > yinit + noScrollZone) ; down
-					send, {WheelDown 1}
-				; horizontal scroll is disabled because it interferes with vertical scrolling
-				; doing this makes scrolling smoother
-				; uncomment these lines to enable horizontal scrolling
-				; if (x < xinit - noScrollZone) ; left
-				; 	send, {WheelLeft 1}
-				; if (x > xinit + noScrollZone) ; right
-				; 	send, {WheelRight 1}
+				if (GetKeyState("Ctrl")) { ; hold ctrl while scrolling for vertical and horizontal scroll
+					verticalScroll(y, yinit)
+					horizontalScroll(x, xinit)
+				} else if (GetKeyState("Shift")) { ; hold shift for horizontal scroll
+					horizontalScroll(x, xinit)
+				} else { ; default is vertical scroll
+					verticalScroll(y, yinit)
+				}
 				; make speed of scroll react to cursor position
 				dist := Round( Sqrt( ( x - xinit )**2 + ( y - yinit )**2 ) ) ; cursor's distance from initial position
 				sleepTime := Max( smooth - ( dist / slow ) ** acceleration, 0 ) ; a lower sleeptime gives a faster scroll

--- a/script.ahk
+++ b/script.ahk
@@ -8,12 +8,12 @@
 		; if no, send a regular middle click
 		; if yes, scroll
 		global hasScrollingStarted := false ; used to allow click then scroll without holding
-		global noScrollZone := 10 ; no scrolling until the mouse moves at least this far
+		noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 		smooth := 80 ; higher smooth value makes scroll less smooth
 		acceleration := 1.09 ; higher acceleration value makes scroll start accelerating sooner
 		slow := 10 ; lower slow value increases scroll speed
 		symbol := Chr(10021) ; html character code for four direction arrow symbol
-		verticalScroll(y, yinit) {
+		verticalScroll(y, yinit, noScrollZone) {
 			if (y < yinit - noScrollZone) {
 				send, {WheelUp 1}
 				hasScrollingStarted := true
@@ -23,7 +23,7 @@
 				hasScrollingStarted := true
 			} ; down
 		}
-		horizontalScroll(x, xinit) {
+		horizontalScroll(x, xinit, noScrollZone) {
 			if (x < xinit - noScrollZone) {
 				send, {WheelLeft 1}
 				hasScrollingStarted := true
@@ -44,12 +44,12 @@
 				MouseGetPos, x , y ; current position of cursor
 				; check the four cases
 				if (GetKeyState("Ctrl")) { ; hold ctrl while scrolling for vertical and horizontal scroll
-					verticalScroll(y, yinit)
-					horizontalScroll(x, xinit)
+					verticalScroll(y, yinit, noScrollZone)
+					horizontalScroll(x, xinit, noScrollZone)
 				} else if (GetKeyState("Shift")) { ; hold shift for horizontal scroll
-					horizontalScroll(x, xinit)
+					horizontalScroll(x, xinit, noScrollZone)
 				} else { ; default is vertical scroll
-					verticalScroll(y, yinit)
+					verticalScroll(y, yinit, noScrollZone)
 				}
 				; make speed of scroll react to cursor position
 				dist := Round( Sqrt( ( x - xinit )**2 + ( y - yinit )**2 ) ) ; cursor's distance from initial position
@@ -61,10 +61,12 @@
 	return
 
 	MButton Up:: ; on middle mouse button release, do the following
-		if (hasScrollingStarted) { ; check if click then scroll is activated
+		if (hasScrollingStarted) { ; if the user has scrolled, scrolling without holding is off
 			scroll := false ; cancel scroll
 			ToolTip ; cancel tooltip
 			hasScrollingStarted := false
+		} else { ; if the user clicked and released without scrolling, scrolling without holding is on
+			hasScrollingStarted := true
 		}
 	return
 #IfWinActive

--- a/script.ahk
+++ b/script.ahk
@@ -59,9 +59,7 @@
 			}
 		}
 	return
-#IfWinActive
 
-#IfWinActive ahk_exe Code.exe ; script is only active in VS Code
 	MButton Up:: ; on middle mouse button release, do the following
 		if (hasScrollingStarted) { ; check if click then scroll is activated
 			scroll := false ; cancel scroll

--- a/script.ahk
+++ b/script.ahk
@@ -7,22 +7,31 @@
 		; check if the cursor is in a text area
 		; if no, send a regular middle click
 		; if yes, scroll
+		global hasScrollingStarted := false ; used to allow click then scroll without holding
 		global noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 		smooth := 80 ; higher smooth value makes scroll less smooth
 		acceleration := 1.09 ; higher acceleration value makes scroll start accelerating sooner
 		slow := 10 ; lower slow value increases scroll speed
 		symbol := Chr(10021) ; html character code for four direction arrow symbol
 		verticalScroll(y, yinit) {
-			if (y < yinit - noScrollZone) ; up
+			if (y < yinit - noScrollZone) {
 				send, {WheelUp 1}
-			if (y > yinit + noScrollZone) ; down
+				hasScrollingStarted := true
+			} ; up
+			if (y > yinit + noScrollZone) {
 				send, {WheelDown 1}
+				hasScrollingStarted := true
+			} ; down
 		}
 		horizontalScroll(x, xinit) {
-			if (x < xinit - noScrollZone) ; left
+			if (x < xinit - noScrollZone) {
 				send, {WheelLeft 1}
-			if (x > xinit + noScrollZone) ; right
+				hasScrollingStarted := true
+			} ; left
+			if (x > xinit + noScrollZone) {
 				send, {WheelRight 1}
+				hasScrollingStarted := true
+			} ; right
 		}
 		if (A_Cursor != "IBeam") {
 			send {MButton}
@@ -54,7 +63,10 @@
 
 #IfWinActive ahk_exe Code.exe ; script is only active in VS Code
 	MButton Up:: ; on middle mouse button release, do the following
-		scroll := false ; cancel scroll
-		ToolTip ; cancel tooltip
+		if (hasScrollingStarted) { ; check if click then scroll is activated
+			scroll := false ; cancel scroll
+			ToolTip ; cancel tooltip
+			hasScrollingStarted := false
+		}
 	return
 #IfWinActive

--- a/script.ahk
+++ b/script.ahk
@@ -7,6 +7,10 @@
 		; check if the cursor is in a text area
 		; if no, send a regular middle click
 		; if yes, scroll
+		smooth := 80 ; higher smooth value makes scroll less smooth
+		acceleration := 1.09 ; higher acceleration value makes scroll start accelerating sooner
+		slow := 10 ; lower slow value increases scroll speed
+		symbol := Chr(10021) ; html character code for four direction arrow symbol
 		if (A_Cursor != "IBeam") {
 			send {MButton}
 		} else {
@@ -14,8 +18,6 @@
 			noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 			MouseGetPos, xinit , yinit ; initial position of cursor when middle mouse button is clicked
 			while scroll { ; loop until middle mouse button is released
-				; html character code for four direction arrow symbol
-				symbol := Chr(10021)
 				; the tooltip is locked to its initial position
 				ToolTip, %symbol%, xinit, yinit ; visual indication that scroll is active
 				MouseGetPos, x , y ; current position of cursor
@@ -24,13 +26,16 @@
 					send, {WheelUp 1}
 				if (y > yinit + noScrollZone) ; down
 					send, {WheelDown 1}
-				if (x < xinit - noScrollZone) ; left
-					send, {WheelLeft 1}
-				if (x > xinit + noScrollZone) ; right
-					send, {WheelRight 1}
+				; horizontal scroll is disabled because it interferes with vertical scrolling
+				; doing this makes scrolling smoother
+				; uncomment these lines to enable horizontal scrolling
+				; if (x < xinit - noScrollZone) ; left
+				; 	send, {WheelLeft 1}
+				; if (x > xinit + noScrollZone) ; right
+				; 	send, {WheelRight 1}
 				; make speed of scroll react to cursor position
 				dist := Round( Sqrt( ( x - xinit )**2 + ( y - yinit )**2 ) ) ; cursor's distance from initial position
-				sleepTime := Max( 300 - dist, 0 ) ; a lower sleeptime gives a faster scroll
+				sleepTime := Max( smooth - ( dist / slow ) ** acceleration, 0 ) ; a lower sleeptime gives a faster scroll
 				; sleepTime:= 100 ; uncomment this line to get a constant scroll speed
 				sleep sleepTime ; loop pauses for this length of time
 			}

--- a/script.ahk
+++ b/script.ahk
@@ -14,7 +14,10 @@
 			noScrollZone := 10 ; no scrolling until the mouse moves at least this far
 			MouseGetPos, xinit , yinit ; initial position of cursor when middle mouse button is clicked
 			while scroll { ; loop until middle mouse button is released
-				ToolTip, SCROLLING ; visual indication that scroll is active
+				; html character code for four direction arrow symbol
+				symbol := Chr(10021)
+				; the tooltip is locked to its initial position
+				ToolTip, %symbol%, xinit, yinit ; visual indication that scroll is active
 				MouseGetPos, x , y ; current position of cursor
 				; check the four cases
 				if (y < yinit - noScrollZone) ; up


### PR DESCRIPTION
Hi, this project is really awesome! It was so annoying not being able to scroll with the middle mouse button in VS Code so this is really helpful. 

I added some things that I thought might be useful:

1. (Changed tooltip) The text on the tool tip is now a four directional arrow symbol.

1. (Changed tooltip) The tool tip now stays locked in its initial position when scrolling starts, to show where you started scrolling.

1. (Changed scroll speed equation) I changed the scroll speed equation to be smoother and added acceleration.

1. (Shift to start horizontal scrolling) Pressing the middle mouse button only scrolls vertically by default. If Ctrl is also pressed while scrolling, horizontal scroll is enabled. Pressing Shift only allows horizontal scroll. This is because the horizontal scroll was changing the speed of the vertical scroll even when horizontal scroll wasn't possible.

1. (Added click and scroll without holding) Pressing and releasing the middle mouse button without scrolling lets the user now scroll without holding the button. This is cancelled by pressing the middle mouse button again after scrolling. 

1. (Formatting) Both hotkeys are now in the same if block because they both run in VS Code.

1. (Cancel scroll no hold by clicking again) If the middle mouse button is pressed and released without scrolling, scrolling will be cancelled if the middle mouse button is pressed again.


Please let me know if you have any questions.
Thanks!